### PR TITLE
feat: add share menu with promo copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
   h1{font-size:clamp(20px, 3vw, 28px); margin:0; letter-spacing:.2px;}
   .btn{appearance:none; border:1px solid var(--accent); background:var(--accent); color:#fff; padding:8px 12px; border-radius:10px; cursor:pointer; font-weight:600;}
   .btn.secondary{background:transparent; color:var(--accent);}
+  .actions{display:flex; gap:8px; position:relative;}
+  .share-menu{position:absolute; right:0; top:calc(100% + 4px); background:#fff; border:1px solid var(--line); border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,.1); padding:8px; display:none;}
+  .share-menu a, .share-menu button{display:block; padding:6px 8px; text-decoration:none; color:var(--ink); background:none; border:none; width:100%; text-align:left; cursor:pointer;}
+  .share-menu.show{display:block;}
   main{max-width:1024px; margin:0 auto; padding:18px;}
   .note{background:var(--card); border:1px solid var(--line); border-radius:12px; padding:12px 14px; margin:16px 0;}
   h2{margin-top:28px; border-bottom:2px solid var(--line); padding-bottom:6px;}
@@ -59,6 +63,13 @@
 <h1>Comprehensive Geometry Formulas — 2D &amp; 3D (Student Edition)</h1>
 <div class="actions">
 <button class="btn" onclick="window.print()">Print / Export to PDF</button>
+<button class="btn secondary" id="share-btn">Share</button>
+<div id="share-menu" class="share-menu no-print">
+<a id="share-twitter" target="_blank" rel="noopener">Share on Twitter</a>
+<a id="share-facebook" target="_blank" rel="noopener">Share on Facebook</a>
+<a id="share-linkedin" target="_blank" rel="noopener">Share on LinkedIn</a>
+<button id="copy-text">Copy Promo Text</button>
+</div>
 </div>
 </div>
 </header>
@@ -870,5 +881,35 @@
     Tip: Use the <strong>Print / Export to PDF</strong> button for a clean A4 PDF. This document is self‑contained (no external libraries) and uses MathML for crisp, LaTeX‑style formulas.
   </footer>
 </main>
+<script>
+  (function(){
+    const shareBtn=document.getElementById('share-btn');
+    const menu=document.getElementById('share-menu');
+    const promoText='Comprehensive Geometry Formulas — printable A4 reference sheet:\n'+location.href;
+    shareBtn?.addEventListener('click',async()=>{
+      if(navigator.share){
+        try{await navigator.share({title:document.title,text:promoText,url:location.href});}
+        catch(e){}
+      }else{
+        menu.classList.toggle('show');
+      }
+    });
+    document.getElementById('share-twitter').href='https://twitter.com/intent/tweet?text='+encodeURIComponent(promoText)+'&url='+encodeURIComponent(location.href);
+    document.getElementById('share-facebook').href='https://www.facebook.com/sharer/sharer.php?u='+encodeURIComponent(location.href)+'&quote='+encodeURIComponent(promoText);
+    document.getElementById('share-linkedin').href='https://www.linkedin.com/shareArticle?mini=true&url='+encodeURIComponent(location.href)+'&title='+encodeURIComponent(document.title)+'&summary='+encodeURIComponent(promoText);
+    document.getElementById('copy-text').addEventListener('click',()=>{
+      navigator.clipboard.writeText(promoText).then(()=>{
+        const b=document.getElementById('copy-text');
+        b.textContent='Copied!';
+        setTimeout(()=>b.textContent='Copy Promo Text',2000);
+      });
+    });
+    document.addEventListener('click',e=>{
+      if(!menu.contains(e.target)&&e.target!==shareBtn){
+        menu.classList.remove('show');
+      }
+    });
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add share button with links to Twitter, Facebook and LinkedIn
- allow copying a promotional text snippet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beb826804c832db984d43d52dbd86c