### PR TITLE
Refactor footer translation handling

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -70,7 +70,7 @@ export default async function LocaleLayout({
           </Script>
           <Header />
           <main className="mx-auto w-full max-w-5xl px-4 py-8 lg:px-8">{children}</main>
-          <Footer />
+          <Footer siteName={t('siteName')} tagline={t('tagline')} />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,18 +1,18 @@
-"use client";
+interface FooterProps {
+  siteName: string;
+  tagline: string;
+}
 
-import {useTranslations} from 'next-intl';
-
-export default function Footer() {
-  const t = useTranslations('common');
+export default function Footer({siteName, tagline}: FooterProps) {
   const year = new Date().getFullYear();
 
   return (
     <footer className="mt-12 border-t border-line/60 bg-white/70 py-6">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-2 px-4 text-sm text-muted lg:px-8">
         <p>
-          © {year} {t('siteName')}
+          © {year} {siteName}
         </p>
-        <p>{t('tagline')}</p>
+        <p>{tagline}</p>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- convert the footer into a server component that accepts localized copy via props instead of calling client-only hooks
- pass the translated site name and tagline from the locale layout when rendering the footer

## Testing
- not run (npm install fails with 403 when attempting to install dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68cd1386faec832d8859218721d6ee3b